### PR TITLE
Implement revoke auth token route

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = twitterapiv2
-version = 0.0.6
+version = 0.0.7
 description = application authentication and access to Twitter api v2 endpoints
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -21,7 +21,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    secretbox==2.2.0
+    secretbox==2.2.1
     urllib3==1.26.7
 python_requires = >=3.8
 package_dir =

--- a/tests/auth_client_test.py
+++ b/tests/auth_client_test.py
@@ -49,6 +49,21 @@ def test_set_bearer_token() -> None:
     assert os.environ["TW_BEARER_TOKEN"]
 
 
+# @api_recorder.use_cassette()
+def test_revoke_bearer_token() -> None:
+    # NOTE: To re-record this test you need to inject valid creds to conftest
+
+    # assert os.getenv("TW_BEARER_TOKEN") is None
+    client = AuthClient()
+    # TODO: (preocts) This endpoint does't work. No response from Twitter
+    with pytest.raises(NotImplementedError):
+        client.revoke_bearer_token()
+    # client.set_bearer_token()
+    # assert os.environ["TW_BEARER_TOKEN"]
+    # client.revoke_bearer_token()
+    # assert os.getenv("TW_BEARER_TOKEN") is None
+
+
 @api_recorder.use_cassette()
 def test_invalid_bearer_request() -> None:
     client = AuthClient()


### PR DESCRIPTION
PENDING: This route does not work on Twitter's end. Multiple reports as
late as Feb'21 found, no solution. Code staged as comments.